### PR TITLE
Implement the OnlyText feature

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -40,9 +40,9 @@ type (
 	// See `Entry` for more.
 	OutFilter struct {
 		// Match should match (against regex expression if NoRegex is false, default behavior).
-		Match string `yaml:"match,omitempty"`
+		Match []string `yaml:"match,omitempty"`
 		// NotMatch should not match (against regex expression if NoRegex is false, default behavior).
-		NotMatch string `yaml:"not_match,omitempty"`
+		NotMatch []string `yaml:"not_match,omitempty"`
 
 		/* More options below... */
 
@@ -68,7 +68,11 @@ func canPassAgainst(output, against string, noregex bool) (bool, error) {
 func (f OutFilter) check(output string) (bool, error) {
 	var errMsg string
 
-	if v := f.Match; v != "" {
+	for _, v := range f.Match {
+		if v == "" {
+			continue
+		}
+
 		// check for match.
 		pass, errPass := canPassAgainst(v, output, f.NoRegex)
 		if errPass != nil {
@@ -80,7 +84,11 @@ func (f OutFilter) check(output string) (bool, error) {
 		}
 	}
 
-	if v := f.NotMatch; v != "" {
+	for _, v := range f.NotMatch {
+		if v == "" {
+			continue
+		}
+
 		// check for not match (too).
 		pass, errPass := canPassAgainst(v, output, f.NoRegex)
 		if errPass != nil {
@@ -111,7 +119,7 @@ func (e Entry) testBackwards(stdout, stderr string) (bool, error) {
 
 		pass, errPass := canPassAgainst(v, stdout, e.NoRegex)
 		if errPass != nil {
-			errMsg = fmt.Sprintf("Stdout_has Bad Regexp: %v. \n", errMsg, errPass)
+			errMsg = fmt.Sprintf("Stdout_has Bad Regexp: %v. \n", errPass)
 		}
 
 		if !pass {

--- a/entry.go
+++ b/entry.go
@@ -26,7 +26,7 @@ type (
 		// `SleepAfter` will wait for 'x' duration after the execution of this command.
 		SleepAfter time.Duration `yaml:"sleep_after,omitempty"`
 
-		// keep for backwards compability.
+		// keep for backwards compatibility.
 		StdoutExpect    []string `yaml:"stdout_has,omitempty"`
 		StdoutNotExpect []string `yaml:"stdout_not_has,omitempty"`
 		StderrExpect    []string `yaml:"stderr_has,omitempty"`

--- a/entry.go
+++ b/entry.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -17,6 +18,13 @@ type (
 		NoLog   bool          `yaml:"nolog,omitempty"`
 		EnvVars []string      `yaml:"env,omitempty"`
 		Timeout time.Duration `yaml:"timeout,omitempty"`
+
+		// It differs from the `Timeout`,
+		// `SleepBefore` will wait for 'x' duration before the execution of this command.
+		SleepBefore time.Duration `yaml:"sleep_before,omitempty"`
+		// It differs from the `Timeout`,
+		// `SleepAfter` will wait for 'x' duration after the execution of this command.
+		SleepAfter time.Duration `yaml:"sleep_after,omitempty"`
 
 		// keep for backwards compability.
 		StdoutExpect    []string `yaml:"stdout_has,omitempty"`
@@ -126,7 +134,7 @@ func (f OutFilter) check(output string) (bool, error) {
 	}
 
 	if errMsg != "" {
-		return false, fmt.Errorf(errMsg)
+		return false, errors.New(errMsg)
 	}
 
 	return true, nil
@@ -200,7 +208,7 @@ func (e Entry) testBackwards(stdout, stderr string) (bool, error) {
 	}
 
 	if errMsg != "" {
-		return false, fmt.Errorf(errMsg)
+		return false, errors.New(errMsg)
 	}
 
 	return true, nil

--- a/entry.go
+++ b/entry.go
@@ -27,8 +27,8 @@ type (
 		// Useful for matching [raw array results]).
 		NoRegex bool `yaml:"noregex,omitempty"`
 
-		Stdout []OutFilter `yaml:"stdout,omitempty"`
-		Stderr []OutFilter `yaml:"stderr,omitempty"`
+		Stdout OutFilters `yaml:"stdout,omitempty"`
+		Stderr OutFilters `yaml:"stderr,omitempty"`
 
 		IgnoreExitCode bool   `yaml:"ignore_exit_code,omitempty"`
 		Skip           string `yaml:"skip,omitempty"`   // Skips only if true
@@ -50,7 +50,28 @@ type (
 		// Useful for matching [raw array results]).
 		NoRegex bool `yaml:"noregex,omitempty"`
 	}
+
+	// OutFilters is a set of `OutFilter`.
+	OutFilters []OutFilter
 )
+
+// GetMatches simply returns the text of all `Match` inside "filters".
+func (filters OutFilters) GetMatches() (matches []string) {
+	for _, filter := range filters {
+		matches = append(matches, filter.Match...)
+	}
+
+	return
+}
+
+// GetNotMatches simply returns the text of all `NotMatch` inside "filters".
+func (filters OutFilters) GetNotMatches() (notMatches []string) {
+	for _, filter := range filters {
+		notMatches = append(notMatches, filter.NotMatch...)
+	}
+
+	return
+}
 
 func canPassAgainst(output, against string, noregex bool) (bool, error) {
 	if noregex {

--- a/entry.go
+++ b/entry.go
@@ -73,7 +73,7 @@ func (filters OutFilters) GetNotMatches() (notMatches []string) {
 	return
 }
 
-func canPassAgainst(output, against string, noregex bool) (bool, error) {
+func canPassAgainst(against, output string, noregex bool) (bool, error) {
 	if noregex {
 		if strings.Contains(output, "\n") {
 			output = strings.Replace(output, "\n", "", -1)
@@ -83,7 +83,7 @@ func canPassAgainst(output, against string, noregex bool) (bool, error) {
 		return output == against, nil
 	}
 
-	return regexp.MatchString(output, against)
+	return regexp.MatchString(against, output)
 }
 
 func (f OutFilter) check(output string) (bool, error) {

--- a/entry.go
+++ b/entry.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type (
+	// Entry contains the test case's entries' structure, see examples for more.
+	Entry struct {
+		Name    string        `yaml:"name"`
+		WorkDir string        `yaml:"workdir"`
+		Command string        `yaml:"command,omitempty"`
+		Stdin   string        `yaml:"stdin,omitempty"`
+		NoLog   bool          `yaml:"nolog,omitempty"`
+		EnvVars []string      `yaml:"env,omitempty"`
+		Timeout time.Duration `yaml:"timeout,omitempty"`
+
+		// keep for backwards compability.
+		StdoutExpect    []string `yaml:"stdout_has,omitempty"`
+		StdoutNotExpect []string `yaml:"stdout_not_has,omitempty"`
+		StderrExpect    []string `yaml:"stderr_has,omitempty"`
+		StderrNotExpect []string `yaml:"stderr_not_has,omitempty"`
+		// NoRegex if true disables the regex matching which is the default behavior for "stdout_has", "stdout_not_has", "stderr_has", "stderr_not_has".
+		// Useful for matching [raw array results]).
+		NoRegex bool `yaml:"noregex,omitempty"`
+
+		Stdout []OutFilter `yaml:"stdout,omitempty"`
+		Stderr []OutFilter `yaml:"stderr,omitempty"`
+
+		IgnoreExitCode bool   `yaml:"ignore_exit_code,omitempty"`
+		Skip           string `yaml:"skip,omitempty"`   // Skips only if true
+		NoSkip         string `yaml:"noskip,omitempty"` // Skips if it is set and not true
+	}
+
+	// OutFilter describes the stdout and stderr output's search expectation.
+	//
+	// See `Entry` for more.
+	OutFilter struct {
+		// Match should match (against regex expression if NoRegex is false, default behavior).
+		Match string `yaml:"match,omitempty"`
+		// NotMatch should not match (against regex expression if NoRegex is false, default behavior).
+		NotMatch string `yaml:"not_match,omitempty"`
+
+		/* More options below... */
+
+		// NoRegex if true disables the regex matching, which is the default behavior.
+		// Useful for matching [raw array results]).
+		NoRegex bool `yaml:"noregex,omitempty"`
+	}
+)
+
+func canPassAgainst(output, against string, noregex bool) (bool, error) {
+	if noregex {
+		if strings.Contains(output, "\n") {
+			output = strings.Replace(output, "\n", "", -1)
+			against = strings.Replace(against, "\n", "", -1)
+		}
+
+		return output == against, nil
+	}
+
+	return regexp.MatchString(output, against)
+}
+
+func (f OutFilter) check(output string) (bool, error) {
+	var errMsg string
+
+	if v := f.Match; v != "" {
+		// check for match.
+		pass, errPass := canPassAgainst(v, output, f.NoRegex)
+		if errPass != nil {
+			errMsg = fmt.Sprintf("match: bad regexp: %v. \n", errPass)
+		}
+
+		if !pass {
+			errMsg = fmt.Sprintf("%smatch: should expected '%s'.\n", errMsg, v)
+		}
+	}
+
+	if v := f.NotMatch; v != "" {
+		// check for not match (too).
+		pass, errPass := canPassAgainst(v, output, f.NoRegex)
+		if errPass != nil {
+			errMsg = fmt.Sprintf("%snot_match: bad regexp: %v. \n", errMsg, errPass)
+		}
+
+		if pass {
+			errMsg = fmt.Sprintf("%snot_match: should not expected '%s'.\n", errMsg, v)
+		} else if errPass == nil {
+			pass = true // we can ignore it because we only check for errMsg != "", it's here for readability.
+		}
+	}
+
+	if errMsg != "" {
+		return false, fmt.Errorf(errMsg)
+	}
+
+	return true, nil
+}
+
+func (e Entry) testBackwards(stdout, stderr string) (bool, error) {
+	var errMsg string
+
+	for _, v := range e.StdoutExpect {
+		if v == "" {
+			continue
+		}
+
+		pass, errPass := canPassAgainst(v, stdout, e.NoRegex)
+		if errPass != nil {
+			errMsg = fmt.Sprintf("Stdout_has Bad Regexp: %v. \n", errMsg, errPass)
+		}
+
+		if !pass {
+			errMsg = fmt.Sprintf("%sStdout_has not matched expected '%s'.\n", errMsg, v)
+		}
+	}
+
+	for _, v := range e.StdoutNotExpect {
+		if v == "" {
+			continue
+		}
+
+		pass, errPass := canPassAgainst(v, stdout, e.NoRegex)
+		if errPass != nil {
+			errMsg = fmt.Sprintf("%sStdout_not_has Bad Regexp: %v. \n", errMsg, errPass)
+		}
+
+		if pass {
+			errMsg = fmt.Sprintf("%sStdout_not_has not matched expected '%s'.\n", errMsg, v)
+		} else if errPass == nil {
+			pass = true // pass the test.
+		}
+	}
+
+	for _, v := range e.StderrExpect {
+		if v == "" {
+			continue
+		}
+
+		pass, errPass := canPassAgainst(v, stderr, e.NoRegex)
+		if errPass != nil {
+			errMsg = fmt.Sprintf("%sStderr_has Bad Regexp: %v. \n", errMsg, errPass)
+		}
+
+		if !pass {
+			errMsg = fmt.Sprintf("%sStderr_has not matched expected '%s'.\n", errMsg, v)
+		}
+	}
+
+	for _, v := range e.StderrNotExpect {
+		if v == "" {
+			continue
+		}
+
+		pass, errPass := canPassAgainst(v, stderr, e.NoRegex)
+		if errPass != nil {
+			errMsg = fmt.Sprintf("%sStderr_has Bad Regexp: %v. \n", errMsg, errPass)
+		}
+
+		if pass {
+			errMsg = fmt.Sprintf("%sStderr_has not matched expected '%s'.\n", errMsg, v)
+		} else if errPass == nil {
+			pass = true // we can ignore it because we only check for errMsg != "", it's here for readability.
+		}
+	}
+
+	if errMsg != "" {
+		return false, fmt.Errorf(errMsg)
+	}
+
+	return true, nil
+}
+
+// Test runs the tests based on the entry's fields and returns false if failed.
+// The error is empty if test passed, otherwise it contains the necessary information text that
+// the caller should know about the reason of failure of the particular test.
+func (e Entry) Test(stdout, stderr string) (bool, error) {
+	// here we can mix the old and new syntax,
+	// first check if with the old syntax passed, if passed and has new syntax is there, check that as well, otherwise fail.
+	shouldFirstCheckForOld := len(e.StderrExpect) > 0 || len(e.StderrNotExpect) > 0
+	if shouldFirstCheckForOld {
+		if _, err := e.testBackwards(stdout, stderr); err != nil {
+			return false, err
+		}
+	}
+
+	for i, filter := range e.Stdout {
+		if _, err := filter.check(stdout); err != nil {
+			err = fmt.Errorf("stdout[%d]: %s", i, err.Error())
+			return false, err
+		}
+	}
+
+	for i, filter := range e.Stderr {
+		if _, err := filter.check(stderr); err != nil {
+			err = fmt.Errorf("stderr[%d]: %s", i, err.Error())
+			return false, err
+		}
+	}
+
+	return true, nil
+}

--- a/entry.go
+++ b/entry.go
@@ -73,13 +73,15 @@ func (filters OutFilters) GetNotMatches() (notMatches []string) {
 	return
 }
 
+func removeNewLine(s string) string {
+	return strings.TrimRightFunc(s, func(c rune) bool {
+		return c == '\r' || c == '\n'
+	})
+}
+
 func canPassAgainst(against, output string, noregex bool) (bool, error) {
 	if noregex {
-		if strings.Contains(output, "\n") {
-			output = strings.Replace(output, "\n", "", -1)
-			against = strings.Replace(against, "\n", "", -1)
-		}
-
+		against, output = removeNewLine(against), removeNewLine(output)
 		return output == against, nil
 	}
 

--- a/entry_group.go
+++ b/entry_group.go
@@ -91,7 +91,7 @@ func (l FileEntryLoader) Load(groups *[]EntryGroup) error {
 		if err = yaml.Unmarshal(data, &newGroups); err != nil {
 			errMsg := fmt.Sprintf("error reading configuration file(%s): %v", file, err)
 			if idx > 0 {
-				loadedSuc := append(l[idx-1:idx], l[idx+1:]...)
+				loadedSuc := l[0:idx]
 				errMsg += fmt.Sprintf(".\nLoaded: %s", strings.Join(loadedSuc, ", "))
 			}
 

--- a/entry_group.go
+++ b/entry_group.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type EntryGroup struct {
+	Name    string            `yaml:"name"`
+	Entries []Entry           `yaml:"entries"`
+	Title   string            `yaml:"title,omitempty"`
+	Skip    string            `yaml:"skip"`
+	NoSkip  string            `yaml:"noskip,omitempty"`
+	Type    string            `yaml:"type,omitempty"`
+	Vars    map[string]string `yaml:"vars,omitempty"`
+}
+
+// mergeEntryGroups appends the entries of the "newGroups" to the "groups".
+func mergeEntryGroups(groups *[]EntryGroup, newGroups []EntryGroup) {
+	for _, newGroup := range newGroups {
+		merged := false
+		for i, group := range *groups {
+			if newGroup.Name == group.Name {
+				// join variables.
+				if group.Vars == nil {
+					group.Vars = newGroup.Vars
+				} else if newGroup.Vars != nil {
+					for varName, varValue := range newGroup.Vars {
+						group.Vars[varName] = varValue
+					}
+				}
+
+				// join entries.
+				group.Entries = append(group.Entries, newGroup.Entries...)
+				(*groups)[i] = group
+				merged = true
+				break
+			}
+		}
+
+		if !merged {
+			*groups = append(*groups, newGroup)
+		}
+	}
+}
+
+// EntryLoader should be implement by any structure that provides EntryGroup loading functionality.
+//
+// See `FileEntryLoader` for an example.
+type EntryLoader interface {
+	Load(groups *[]EntryGroup) error
+}
+
+// FileEntryLoader is an implementation of the `EntryLoader`
+// which loads a set of `EntryGroup` based on caller-specific yaml files.
+type FileEntryLoader []string
+
+// AddFile adds file(s) to be loaded on `Load`.
+// Note that it doesn't check for file existence, only `Load` does that.
+// func (l *FileEntryLoader) AddFile(files ...string) {
+// 	tmp := *l
+// 	for _, file := range files {
+// 		exists := false
+// 		for _, existingFile := range tmp {
+// 			if file == existingFile {
+// 				exists = true
+// 				break
+// 			}
+// 		}
+
+// 		if !exists {
+// 			tmp = append(tmp, file)
+// 		}
+// 	}
+
+// 	*l = tmp
+// }
+
+// Load updates the "groups" based on the contents of the corresponding yaml files.
+func (l FileEntryLoader) Load(groups *[]EntryGroup) error {
+	for idx, file := range l {
+		data, err := ioutil.ReadFile(file)
+		if err != nil {
+			return err
+		}
+
+		var newGroups []EntryGroup
+		if err = yaml.Unmarshal(data, &newGroups); err != nil {
+			errMsg := fmt.Sprintf("error reading configuration file(%s): %v", file, err)
+			if idx > 0 {
+				loadedSuc := append(l[idx-1:idx], l[idx+1:]...)
+				errMsg += fmt.Sprintf(".\nLoaded: %s", strings.Join(loadedSuc, ", "))
+			}
+
+			if len(l) > idx+1 {
+				errMsg += fmt.Sprintf(", remained: %s", strings.Join(l[idx+1:], ", "))
+			}
+
+			return fmt.Errorf(errMsg)
+		}
+
+		mergeEntryGroups(groups, newGroups)
+	}
+
+	return nil
+}

--- a/entry_test.go
+++ b/entry_test.go
@@ -21,7 +21,7 @@ func TestOutFilterNoRegex(t *testing.T) {
 		if ok {
 			t.Fatalf("expected to not be passed if error")
 		}
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if !ok && err == nil {

--- a/entry_test.go
+++ b/entry_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestOutFilterNoRegex(t *testing.T) {
+	hasAndExpected := `{"categories":{"Infrastructure":[{"id":1,"description":"License is invalid","category":"Infrastructure","enabled":true,"isAvailable":true}]}}\n`
+
+	entry := Entry{
+		Stdout: OutFilters{
+			OutFilter{
+				Match:   []string{hasAndExpected},
+				NoRegex: true,
+			},
+		},
+	}
+
+	ok, err := entry.Test(hasAndExpected, "")
+	if err != nil {
+		if ok {
+			t.Fatalf("expected to not be passed if error")
+		}
+		t.Error(err)
+	}
+
+	if !ok && err == nil {
+		t.Fatalf("expected to be passed if error is nil")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -440,8 +440,8 @@ func textEqual(value, against string, onlyText bool) (bool, error) {
 
 func textTest(t Entry, stdout, stderr string) error {
 	var (
-		pass bool
-		msg  string
+		pass = true
+		msg  = ""
 	)
 
 	for _, v := range t.StdoutExpect {
@@ -464,7 +464,7 @@ func textTest(t Entry, stdout, stderr string) error {
 			continue
 		}
 
-		pass, err := textEqual(v, stderr, t.OnlyText)
+		pass, err := textEqual(v, stdout, t.OnlyText)
 		if err != nil {
 			msg = fmt.Sprintf("%sStdout_not_has Bad Regexp: %v. \n", msg, err)
 		}

--- a/main.go
+++ b/main.go
@@ -431,49 +431,77 @@ func textTest(t Entry, stdout, stderr string) error {
 
 	for _, v := range t.StdoutExpect {
 		if len(v) > 0 {
-			matched, err := regexp.MatchString(v, stdout)
-			if err != nil {
-				pass = false
-				msg = fmt.Sprintf("%sStdout_has Bad Regexp. \n", msg)
-			} else if !matched {
-				pass = false
-				msg = fmt.Sprintf("%sStdout_has not matched expected '%s'.\n", msg, v)
+			if t.NoRegex {
+				pass = v == stdout
+				if !pass {
+					msg = fmt.Sprintf("%sStdout_has not matched expected '%s'.\n", msg, v)
+				}
+			} else {
+				matched, err := regexp.MatchString(v, stdout)
+				if err != nil {
+					pass = false
+					msg = fmt.Sprintf("%sStdout_has Bad Regexp. \n", msg)
+				} else if !matched {
+					pass = false
+					msg = fmt.Sprintf("%sStdout_has not matched expected '%s'.\n", msg, v)
+				}
 			}
 		}
 	}
 	for _, v := range t.StdoutNotExpect {
 		if len(v) > 0 {
-			matched, err := regexp.MatchString(v, stdout)
-			if err != nil {
-				pass = false
-				msg = fmt.Sprintf("%sStdout_not_has Bad Regexp.\n", msg)
-			} else if matched {
-				pass = false
-				msg = fmt.Sprintf("%sStdout_not_has matched not expected '%s'.\n", msg, v)
+			if t.NoRegex {
+				pass = v != stdout
+				if pass {
+					msg = fmt.Sprintf("%sStdout_not_has matched not expected '%s'.\n", msg, v)
+				}
+			} else {
+				matched, err := regexp.MatchString(v, stdout)
+				if err != nil {
+					pass = false
+					msg = fmt.Sprintf("%sStdout_not_has Bad Regexp.\n", msg)
+				} else if matched {
+					pass = false
+					msg = fmt.Sprintf("%sStdout_not_has matched not expected '%s'.\n", msg, v)
+				}
 			}
 		}
 	}
 	for _, v := range t.StderrExpect {
 		if len(v) > 0 {
-			matched, err := regexp.MatchString(v, stderr)
-			if err != nil {
-				pass = false
-				msg = fmt.Sprintf("%sStderr_has Bad Regexp.\n", msg)
-			} else if !matched {
-				pass = false
-				msg = fmt.Sprintf("%sStderr_has not matched expected '%s'.\n", msg, v)
+			if t.NoRegex {
+				pass = v == stderr
+				if !pass {
+					msg = fmt.Sprintf("%sStderr_has not matched expected '%s'.\n", msg, v)
+				}
+			} else {
+				matched, err := regexp.MatchString(v, stderr)
+				if err != nil {
+					pass = false
+					msg = fmt.Sprintf("%sStderr_has Bad Regexp.\n", msg)
+				} else if !matched {
+					pass = false
+					msg = fmt.Sprintf("%sStderr_has not matched expected '%s'.\n", msg, v)
+				}
 			}
 		}
 	}
 	for _, v := range t.StderrNotExpect {
 		if len(v) > 0 {
-			matched, err := regexp.MatchString(v, stderr)
-			if err != nil {
-				pass = false
-				msg = fmt.Sprintf("%sStderr_not_has Bad Regexp.\n", msg)
-			} else if matched {
-				pass = false
-				msg = fmt.Sprintf("%sStderr_not_has matched not expected '%s'.\n", msg, v)
+			if t.NoRegex {
+				pass = v != stderr
+				if pass {
+					msg = fmt.Sprintf("%sStderr_not_has matched not expected '%s'.\n", msg, v)
+				}
+			} else {
+				matched, err := regexp.MatchString(v, stderr)
+				if err != nil {
+					pass = false
+					msg = fmt.Sprintf("%sStderr_not_has Bad Regexp.\n", msg)
+				} else if matched {
+					pass = false
+					msg = fmt.Sprintf("%sStderr_not_has matched not expected '%s'.\n", msg, v)
+				}
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -273,6 +273,14 @@ func main() {
 			//   cmd := exec.Command("echo", args[0:]...)
 			// else
 			//   ...
+
+			if v.SleepBefore > 0 {
+				if !v.NoLog {
+					logger.Printf("Wait for %d seconds before run the test '%s'\n", int(v.SleepBefore.Seconds()), v.Name)
+				}
+				time.Sleep(v.SleepBefore)
+			}
+
 			var cmd *exec.Cmd
 			if len(args) == 0 { // Empty command?
 				logger.Printf("Entry %s is missing the command field. Aborting.\n", v.Name)
@@ -358,6 +366,13 @@ func main() {
 				t.Test = v
 				resultGroup.Results = append(resultGroup.Results, t)
 				resultGroup.TotalTime += t.Time
+			}
+
+			if v.SleepAfter > 0 {
+				if !v.NoLog {
+					logger.Printf("Wait for %d seconds after the test '%s' ran\n", int(v.SleepAfter.Seconds()), v.Name)
+				}
+				time.Sleep(v.SleepAfter)
 			}
 		}
 		resultGroup.Total = resultGroup.Passed + resultGroup.Errors

--- a/main.go
+++ b/main.go
@@ -427,8 +427,10 @@ func main() {
 
 func textEqual(value, against string, onlyText bool) (bool, error) {
 	if onlyText {
-		value = strings.Replace(value, "\n", "", -1)
-		against = strings.Replace(against, "\n", "", -1)
+		if strings.Contains(value, "\n") {
+			value = strings.Replace(value, "\n", "", -1)
+			against = strings.Replace(against, "\n", "", -1)
+		}
 
 		return value == against, nil
 	}

--- a/main.go
+++ b/main.go
@@ -243,16 +243,10 @@ func main() {
 				v.StderrNotExpect,
 				v.StdoutExpect,
 				v.StdoutNotExpect,
-			}
-
-			for _, filter := range v.Stdout {
-				replaceInArrays[0] = append(replaceInArrays[0], filter.Match...)
-				replaceInArrays[0] = append(replaceInArrays[0], filter.NotMatch...)
-			}
-
-			for _, filter := range v.Stderr {
-				replaceInArrays[0] = append(replaceInArrays[0], filter.Match...)
-				replaceInArrays[0] = append(replaceInArrays[0], filter.NotMatch...)
+				v.Stderr.GetMatches(),
+				v.Stderr.GetNotMatches(),
+				v.Stdout.GetMatches(),
+				v.Stdout.GetNotMatches(),
 			}
 
 			for _, v2 := range replaceInArrays {

--- a/main.go
+++ b/main.go
@@ -244,6 +244,17 @@ func main() {
 				v.StdoutExpect,
 				v.StdoutNotExpect,
 			}
+
+			for _, filter := range v.Stdout {
+				replaceInArrays[0] = append(replaceInArrays[0], filter.Match...)
+				replaceInArrays[0] = append(replaceInArrays[0], filter.NotMatch...)
+			}
+
+			for _, filter := range v.Stderr {
+				replaceInArrays[0] = append(replaceInArrays[0], filter.Match...)
+				replaceInArrays[0] = append(replaceInArrays[0], filter.NotMatch...)
+			}
+
 			for _, v2 := range replaceInArrays {
 				for k3, v3 := range v2 {
 					v2[k3] = replaceVars(replaceUnique(v3), localVars, globalVars)

--- a/main.go
+++ b/main.go
@@ -230,31 +230,6 @@ func main() {
 				continue
 			}
 
-			// If unique strings are asked, replace the placeholders
-			// Also replace local and global vars
-			v.Command = replaceUnique(v.Command)
-			v.Command = replaceVars(v.Command, localVars, globalVars)
-			v.Stdin = replaceUnique(v.Stdin)
-			v.Stdin = replaceVars(v.Stdin, localVars, globalVars)
-			v.Name = replaceVars(v.Name, localVars, globalVars)
-			var replaceInArrays = [][]string{
-				v.EnvVars,
-				v.StderrExpect,
-				v.StderrNotExpect,
-				v.StdoutExpect,
-				v.StdoutNotExpect,
-				v.Stderr.GetMatches(),
-				v.Stderr.GetNotMatches(),
-				v.Stdout.GetMatches(),
-				v.Stdout.GetNotMatches(),
-			}
-
-			for _, v2 := range replaceInArrays {
-				for k3, v3 := range v2 {
-					v2[k3] = replaceVars(replaceUnique(v3), localVars, globalVars)
-				}
-			}
-
 			// If timeout is missing, set the default. If it is <0, set infinite.
 			if v.Timeout == 0 {
 				v.Timeout = *defaultTimeout
@@ -262,6 +237,7 @@ func main() {
 				v.Timeout = time.Duration(365 * 24 * time.Hour)
 			}
 
+			v.MapVars(localVars, globalVars)
 			args, err := shellwords.Parse(v.Command)
 
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -436,7 +436,7 @@ func assignMultiUseUniques(matches []string) {
 	}
 }
 
-// checkVarNames verifies that variable names are withing acceptable criteria
+// checkVarNames verifies that variable names are within acceptable criteria
 // and returns a new map where keys are enclosed within ampersands
 // so we can check for %VARNAME% entries.
 func checkVarNames(vars map[string]string) (map[string]string, error) {

--- a/main.go
+++ b/main.go
@@ -425,89 +425,91 @@ func main() {
 	}
 }
 
+func textEqual(value, against string, onlyText bool) (bool, error) {
+	if onlyText {
+		value = strings.Replace(value, "\n", "", -1)
+		against = strings.Replace(against, "\n", "", -1)
+
+		return value == against, nil
+	}
+
+	return regexp.MatchString(value, against)
+}
+
 func textTest(t Entry, stdout, stderr string) error {
-	var pass = true
-	var msg = ""
+	var (
+		pass bool
+		msg  string
+	)
 
 	for _, v := range t.StdoutExpect {
-		if len(v) > 0 {
-			if t.NoRegex {
-				pass = v == stdout
-				if !pass {
-					msg = fmt.Sprintf("%sStdout_has not matched expected '%s'.\n", msg, v)
-				}
-			} else {
-				matched, err := regexp.MatchString(v, stdout)
-				if err != nil {
-					pass = false
-					msg = fmt.Sprintf("%sStdout_has Bad Regexp. \n", msg)
-				} else if !matched {
-					pass = false
-					msg = fmt.Sprintf("%sStdout_has not matched expected '%s'.\n", msg, v)
-				}
-			}
+		if v == "" {
+			continue
+		}
+
+		pass, err := textEqual(v, stdout, t.OnlyText)
+		if err != nil {
+			msg = fmt.Sprintf("%sStdout_has Bad Regexp: %v. \n", msg, err)
+		}
+
+		if !pass {
+			msg = fmt.Sprintf("%sStdout_has not matched expected '%s'.\n", msg, v)
 		}
 	}
+
 	for _, v := range t.StdoutNotExpect {
-		if len(v) > 0 {
-			if t.NoRegex {
-				pass = v != stdout
-				if pass {
-					msg = fmt.Sprintf("%sStdout_not_has matched not expected '%s'.\n", msg, v)
-				}
-			} else {
-				matched, err := regexp.MatchString(v, stdout)
-				if err != nil {
-					pass = false
-					msg = fmt.Sprintf("%sStdout_not_has Bad Regexp.\n", msg)
-				} else if matched {
-					pass = false
-					msg = fmt.Sprintf("%sStdout_not_has matched not expected '%s'.\n", msg, v)
-				}
-			}
+		if v == "" {
+			continue
+		}
+
+		pass, err := textEqual(v, stderr, t.OnlyText)
+		if err != nil {
+			msg = fmt.Sprintf("%sStdout_not_has Bad Regexp: %v. \n", msg, err)
+		}
+
+		if pass {
+			msg = fmt.Sprintf("%sStdout_not_has not matched expected '%s'.\n", msg, v)
+		} else if err == nil {
+			pass = true // pass the test.
 		}
 	}
+
 	for _, v := range t.StderrExpect {
-		if len(v) > 0 {
-			if t.NoRegex {
-				pass = v == stderr
-				if !pass {
-					msg = fmt.Sprintf("%sStderr_has not matched expected '%s'.\n", msg, v)
-				}
-			} else {
-				matched, err := regexp.MatchString(v, stderr)
-				if err != nil {
-					pass = false
-					msg = fmt.Sprintf("%sStderr_has Bad Regexp.\n", msg)
-				} else if !matched {
-					pass = false
-					msg = fmt.Sprintf("%sStderr_has not matched expected '%s'.\n", msg, v)
-				}
-			}
+		if v == "" {
+			continue
+		}
+
+		pass, err := textEqual(v, stderr, t.OnlyText)
+		if err != nil {
+			msg = fmt.Sprintf("%sStderr_has Bad Regexp: %v. \n", msg, err)
+		}
+
+		if !pass {
+			msg = fmt.Sprintf("%sStderr_has not matched expected '%s'.\n", msg, v)
 		}
 	}
+
 	for _, v := range t.StderrNotExpect {
-		if len(v) > 0 {
-			if t.NoRegex {
-				pass = v != stderr
-				if pass {
-					msg = fmt.Sprintf("%sStderr_not_has matched not expected '%s'.\n", msg, v)
-				}
-			} else {
-				matched, err := regexp.MatchString(v, stderr)
-				if err != nil {
-					pass = false
-					msg = fmt.Sprintf("%sStderr_not_has Bad Regexp.\n", msg)
-				} else if matched {
-					pass = false
-					msg = fmt.Sprintf("%sStderr_not_has matched not expected '%s'.\n", msg, v)
-				}
-			}
+		if v == "" {
+			continue
+		}
+
+		pass, err := textEqual(v, stderr, t.OnlyText)
+		if err != nil {
+			msg = fmt.Sprintf("%sStderr_has Bad Regexp: %v. \n", msg, err)
+		}
+
+		if pass {
+			msg = fmt.Sprintf("%sStderr_has not matched expected '%s'.\n", msg, v)
+		} else if err == nil {
+			pass = true // pass the test.
 		}
 	}
+
 	if !pass {
 		return errors.New(msg)
 	}
+
 	return nil
 }
 

--- a/structs.go
+++ b/structs.go
@@ -15,36 +15,6 @@
 
 package main
 
-import "time"
-
-type Entry struct {
-	Name            string        `yaml:"name"`
-	WorkDir         string        `yaml:"workdir"`
-	Command         string        `yaml:"command,omitempty"`
-	Stdin           string        `yaml:"stdin,omitempty"`
-	NoLog           bool          `yaml:"nolog,omitempty"`
-	EnvVars         []string      `yaml:"env,omitempty"`
-	Timeout         time.Duration `yaml:"timeout,omitempty"`
-	StdoutExpect    []string      `yaml:"stdout_has,omitempty"`
-	StdoutNotExpect []string      `yaml:"stdout_not_has,omitempty"`
-	StderrExpect    []string      `yaml:"stderr_has,omitempty"`
-	StderrNotExpect []string      `yaml:"stderr_not_has,omitempty"`
-	OnlyText        bool          `yaml:"only_text,omitempty"` // disables regex matching for stdout_has, stdout_not_has, stderr_has and stderr_not_has (useful for matching [raw array results]).
-	IgnoreExitCode  bool          `yaml:"ignore_exit_code,omitempty"`
-	Skip            string        `yaml:"skip,omitempty"`   // Skips only if true
-	NoSkip          string        `yaml:"noskip,omitempty"` // Skips if it is set and not true
-}
-
-type EntryGroup struct {
-	Name    string            `yaml:"name"`
-	Entries []Entry           `yaml:"entries"`
-	Title   string            `yaml:"title,omitempty"`
-	Skip    string            `yaml:"skip"`
-	NoSkip  string            `yaml:"noskip,omitempty"`
-	Type    string            `yaml:"type,omitempty"`
-	Vars    map[string]string `yaml:"vars,omitempty"`
-}
-
 type Result struct {
 	Name    string
 	Command string

--- a/structs.go
+++ b/structs.go
@@ -25,6 +25,7 @@ type Entry struct {
 	NoLog           bool          `yaml:"nolog,omitempty"`
 	EnvVars         []string      `yaml:"env,omitempty"`
 	Timeout         time.Duration `yaml:"timeout,omitempty"`
+	NoRegex         bool          `yaml:"noregex",omitempty` // disables regex matching for stdout_has, stdout_not_has, stderr_has and stderr_not_has (useful for matching [raw array results]).
 	StdoutExpect    []string      `yaml:"stdout_has,omitempty"`
 	StdoutNotExpect []string      `yaml:"stdout_not_has,omitempty"`
 	StderrExpect    []string      `yaml:"stderr_has,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -25,12 +25,11 @@ type Entry struct {
 	NoLog           bool          `yaml:"nolog,omitempty"`
 	EnvVars         []string      `yaml:"env,omitempty"`
 	Timeout         time.Duration `yaml:"timeout,omitempty"`
-	NoRegex         bool          `yaml:"noregex",omitempty` // disables regex matching for stdout_has, stdout_not_has, stderr_has and stderr_not_has (useful for matching [raw array results]).
 	StdoutExpect    []string      `yaml:"stdout_has,omitempty"`
 	StdoutNotExpect []string      `yaml:"stdout_not_has,omitempty"`
 	StderrExpect    []string      `yaml:"stderr_has,omitempty"`
 	StderrNotExpect []string      `yaml:"stderr_not_has,omitempty"`
-	OnlyText        bool          `yaml:"only_text,omitempty"` // NI (Not Implemented)
+	OnlyText        bool          `yaml:"only_text,omitempty"` // disables regex matching for stdout_has, stdout_not_has, stderr_has and stderr_not_has (useful for matching [raw array results]).
 	IgnoreExitCode  bool          `yaml:"ignore_exit_code,omitempty"`
 	Skip            string        `yaml:"skip,omitempty"`   // Skips only if true
 	NoSkip          string        `yaml:"noskip,omitempty"` // Skips if it is set and not true


### PR DESCRIPTION
This is useful when "\n" is escaped on `stdout_has` for example but the expected output has a line ending and we want to match exactly the same text value and to omit any regex processing (useful when `[]` are added on the (not) expected stdout/stderr, in order to avoid "Bad Regex" error).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/coyote/6)
<!-- Reviewable:end -->
