### PR TITLE
Add the ability to pass if at least one expected output found and fix acting expected stderr as failure

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -156,7 +156,7 @@ func (f OutFilter) check(output string) (bool, error) {
 		}
 
 		if !pass {
-			matchErrors[i] = append(matchErrors[i], fmt.Sprintf("match: should expected '%s'.", v))
+			matchErrors[i] = append(matchErrors[i], fmt.Sprintf("match: should expected '%s' but got '%s'.", v, output))
 		} else if f.Contains { // we passed at least one case, break.
 			// and delete any previous errors for THIS `match` entry.
 			for j := 0; j < i; j++ {

--- a/entry.go
+++ b/entry.go
@@ -133,6 +133,7 @@ func (f OutFilter) check(output string) (bool, error) {
 		if !pass {
 			errMsg = fmt.Sprintf("%smatch: should expected '%s'.\n", errMsg, v)
 		} else if f.Contains { // we found at least one not expected, stop searchinf for more now.
+			errMsg = ""
 			break
 		}
 	}
@@ -153,6 +154,7 @@ func (f OutFilter) check(output string) (bool, error) {
 		} else if errPass == nil {
 			pass = true     // we can ignore it because we only check for errMsg != "", it's here for readability.
 			if f.Contains { // we found at least one not expected, stop searchinf for more now.
+				errMsg = ""
 				break
 			}
 		}

--- a/entry.go
+++ b/entry.go
@@ -156,7 +156,11 @@ func (f OutFilter) check(output string) (bool, error) {
 		}
 
 		if !pass {
-			matchErrors[i] = append(matchErrors[i], fmt.Sprintf("match: should expected '%s' but got '%s'.", v, output))
+			errMsg := fmt.Sprintf("match: should expected '%s'.", v)
+			if output == "" {
+				errMsg += " Output is empty ''."
+			}
+			matchErrors[i] = append(matchErrors[i], errMsg)
 		} else if f.Contains { // we passed at least one case, break.
 			// and delete any previous errors for THIS `match` entry.
 			for j := 0; j < i; j++ {

--- a/entry.go
+++ b/entry.go
@@ -157,8 +157,11 @@ func (f OutFilter) check(output string) (bool, error) {
 
 		if !pass {
 			matchErrors[i] = append(matchErrors[i], fmt.Sprintf("match: should expected '%s'.", v))
-		} else if f.Contains { // we passed at least one case, break and delete any previous errors for THIS `match` entry.
-			matchErrors[i] = []string{}
+		} else if f.Contains { // we passed at least one case, break.
+			// and delete any previous errors for THIS `match` entry.
+			for j := 0; j < i; j++ {
+				delete(matchErrors, j)
+			}
 			break
 		}
 	}
@@ -178,8 +181,11 @@ func (f OutFilter) check(output string) (bool, error) {
 			notMatchErrors[i] = append(notMatchErrors[i], fmt.Sprintf("not_match: should not expected '%s'.", v))
 		} else if errPass == nil {
 			pass = true     // we can ignore it because we only check for errMsg != "", it's here for readability.
-			if f.Contains { // we passed at least one case, break and delete any previous errors for THIS `not_match` entry.
-				notMatchErrors[i] = []string{}
+			if f.Contains { // we passed at least one case, break.
+				// and delete any previous errors for THIS `match` entry.
+				for j := 0; j < i; j++ {
+					delete(notMatchErrors, j)
+				}
 				break
 			}
 		}

--- a/entry.go
+++ b/entry.go
@@ -57,10 +57,10 @@ type (
 		// NoRegex if true disables the regex matching, which is the default behavior.
 		// Useful for matching [raw array results]).
 		NoRegex bool `yaml:"noregex,omitempty"`
-		// Contains if true then it passes the test if at least one of the Match/NotMatch entries and their content
+		// Partial if true then it passes the test if at least one of the Match/NotMatch entries and their content
 		// exist in the command's output.
 		// Essentialy is a small helper, it can be done with regex as well.
-		Contains bool `yaml:"contains,omitempty"`
+		Partial bool `yaml:"partial,omitempty"`
 	}
 
 	// OutFilters is a set of `OutFilter`.
@@ -103,13 +103,13 @@ func canPassAgainstBackwards(against, output string, noregex bool) (bool, error)
 func canPassAgainst(against, output string, f OutFilter) (bool, error) {
 	if f.NoRegex {
 		against, output = removeNewLine(against), removeNewLine(output)
-		if f.Contains {
+		if f.Partial {
 			return strings.Contains(output, against), nil
 		}
 		return output == against, nil
 	}
 
-	if f.Contains {
+	if f.Partial {
 		return strings.Contains(output, against), nil
 	}
 
@@ -161,7 +161,7 @@ func (f OutFilter) check(output string) (bool, error) {
 				errMsg += " Output is empty ''."
 			}
 			matchErrors[i] = append(matchErrors[i], errMsg)
-		} else if f.Contains { // we passed at least one case, break.
+		} else if f.Partial { // we passed at least one case, break.
 			// and delete any previous errors for THIS `match` entry.
 			for j := 0; j < i; j++ {
 				delete(matchErrors, j)
@@ -184,8 +184,8 @@ func (f OutFilter) check(output string) (bool, error) {
 		if pass {
 			notMatchErrors[i] = append(notMatchErrors[i], fmt.Sprintf("not_match: should not expected '%s'.", v))
 		} else if errPass == nil {
-			pass = true     // we can ignore it because we only check for errMsg != "", it's here for readability.
-			if f.Contains { // we passed at least one case, break.
+			pass = true    // we can ignore it because we only check for errMsg != "", it's here for readability.
+			if f.Partial { // we passed at least one case, break.
 				// and delete any previous errors for THIS `match` entry.
 				for j := 0; j < i; j++ {
 					delete(notMatchErrors, j)

--- a/entry_test.go
+++ b/entry_test.go
@@ -29,64 +29,63 @@ func TestOutFilterNoRegex(t *testing.T) {
 	}
 }
 
-// TODO: cleanup this test.
-func TestOutFilterContains(t *testing.T) {
+func TestOutFilterPartial(t *testing.T) {
 	has := `logs-broker\nnullsink\n`
-	expectingOneOfThem := []string{"nullsink", "or that"}
 
-	entry := Entry{
-		Stdout: OutFilters{
-			OutFilter{
-				Match:    expectingOneOfThem,
-				Contains: true,
+	tests := []struct {
+		entry          Entry
+		shouldPass     bool
+		stdout, stderr string
+	}{
+		{
+			entry: Entry{
+				Name: "test when partial is true, while match[second] does not exist",
+				Stdout: OutFilters{OutFilter{
+					Match:   []string{"nullsink", "not"},
+					Partial: true,
+				}},
 			},
+			shouldPass: true,
+			stdout:     has,
+		},
+		{
+			// this should fail because "Partial" is per match entry.
+			entry: Entry{
+				Name: "test when partial is true for the first filter with a single match but second does not exist and partial is false",
+				Stdout: OutFilters{
+					OutFilter{
+						Match:   append([]string{}, "nullsink"),
+						Partial: true,
+					},
+					OutFilter{
+						Match: []string{"failure"},
+					},
+				},
+			},
+			shouldPass: false,
+			stdout:     has,
+		},
+		{
+			entry: Entry{
+				Name: "test when partial is true but reverse order, first element does not exist but second does",
+				Stdout: OutFilters{OutFilter{
+					Match:   append([]string{}, "not", "logs-broker"),
+					Partial: true,
+				}},
+			},
+			shouldPass: true,
+			stdout:     has,
 		},
 	}
 
-	ok, err := entry.Test(has, "")
-	if err != nil {
-		if ok {
-			t.Fatalf("expected to not be passed if error")
+	for i, tt := range tests {
+		pass, err := tt.entry.Test(tt.stdout, tt.stderr)
+		if tt.shouldPass != pass {
+			if tt.shouldPass {
+				t.Fatalf("[%d] expected to pass but failed for test '%s', error trace: %v", i, tt.entry.Name, err)
+			} else {
+				t.Fatalf("[%d] expected to not pass but passed for test '%s'", i, tt.entry.Name)
+			}
 		}
-		t.Fatal(err)
 	}
-
-	if !ok && err == nil {
-		t.Fatalf("expected to be passed if error is nil")
-	}
-
-	// this should fail because contains is per match entry.
-	entry2 := Entry{
-		Stdout: OutFilters{
-			OutFilter{
-				Match:    append([]string{}, expectingOneOfThem[0]), // test single entry too.
-				Contains: true,
-			},
-			OutFilter{
-				Match: []string{"failure"},
-			},
-		},
-	}
-
-	if _, err := entry2.Test(has, ""); err == nil {
-		t.Fatalf("[entry2] expected to not be passed")
-	}
-
-	entry3 := Entry{
-		Stdout: OutFilters{
-			OutFilter{
-				// test reverse, first element does not exists but second does, it should pass.
-				Match:    append([]string{}, expectingOneOfThem[1], expectingOneOfThem[0]),
-				Contains: true,
-			},
-		},
-	}
-
-	if ok, err = entry3.Test(has, ""); err != nil {
-		if ok {
-			t.Fatalf("[entry3] expected to not be passed if error")
-		}
-		t.Fatal(err)
-	}
-
 }

--- a/entry_test.go
+++ b/entry_test.go
@@ -31,7 +31,7 @@ func TestOutFilterNoRegex(t *testing.T) {
 
 func TestOutFilterContains(t *testing.T) {
 	has := `logs-broker\nnullsink\n`
-	expectingOneOfThem := []string{"nullsink"}
+	expectingOneOfThem := []string{"nullsink", "or that"}
 
 	entry := Entry{
 		Stdout: OutFilters{
@@ -58,7 +58,7 @@ func TestOutFilterContains(t *testing.T) {
 	entry2 := Entry{
 		Stdout: OutFilters{
 			OutFilter{
-				Match:    expectingOneOfThem,
+				Match:    append([]string{}, expectingOneOfThem[0]), // test single entry too.
 				Contains: true,
 			},
 			OutFilter{

--- a/entry_test.go
+++ b/entry_test.go
@@ -28,3 +28,47 @@ func TestOutFilterNoRegex(t *testing.T) {
 		t.Fatalf("expected to be passed if error is nil")
 	}
 }
+
+func TestOutFilterContains(t *testing.T) {
+	has := `logs-broker\nnullsink\n`
+	expectingOneOfThem := []string{"nullsink"}
+
+	entry := Entry{
+		Stdout: OutFilters{
+			OutFilter{
+				Match:    expectingOneOfThem,
+				Contains: true,
+			},
+		},
+	}
+
+	ok, err := entry.Test(has, "")
+	if err != nil {
+		if ok {
+			t.Fatalf("expected to not be passed if error")
+		}
+		t.Fatal(err)
+	}
+
+	if !ok && err == nil {
+		t.Fatalf("expected to be passed if error is nil")
+	}
+
+	// this should fail because contains is per match entry.
+	entry2 := Entry{
+		Stdout: OutFilters{
+			OutFilter{
+				Match:    expectingOneOfThem,
+				Contains: true,
+			},
+			OutFilter{
+				Match: []string{"failure"},
+			},
+		},
+	}
+
+	if _, err := entry2.Test(has, ""); err == nil {
+		t.Fatalf("expected to not be passed")
+	}
+
+}

--- a/entry_test.go
+++ b/entry_test.go
@@ -29,6 +29,7 @@ func TestOutFilterNoRegex(t *testing.T) {
 	}
 }
 
+// TODO: cleanup this test.
 func TestOutFilterContains(t *testing.T) {
 	has := `logs-broker\nnullsink\n`
 	expectingOneOfThem := []string{"nullsink", "or that"}
@@ -68,7 +69,24 @@ func TestOutFilterContains(t *testing.T) {
 	}
 
 	if _, err := entry2.Test(has, ""); err == nil {
-		t.Fatalf("expected to not be passed")
+		t.Fatalf("[entry2] expected to not be passed")
+	}
+
+	entry3 := Entry{
+		Stdout: OutFilters{
+			OutFilter{
+				// test reverse, first element does not exists but second does, it should pass.
+				Match:    append([]string{}, expectingOneOfThem[1], expectingOneOfThem[0]),
+				Contains: true,
+			},
+		},
+	}
+
+	if ok, err = entry3.Test(has, ""); err != nil {
+		if ok {
+			t.Fatalf("[entry3] expected to not be passed if error")
+		}
+		t.Fatal(err)
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -297,7 +297,7 @@ func main() {
 			// Perform a textTest on outputs.
 			_, textErr := v.Test(stdout, stderr)
 
-			if err != nil && timerLive && !v.IgnoreExitCode {
+			if err != nil && timerLive && !v.IgnoreExitCode && textErr != nil {
 				logger.Printf("Error, command '%s', test '%s'. Error: %s, Stderr: %s\n", v.Command, v.Name, err.Error(), strconv.Quote(stderr))
 			} else if err != nil && !timerLive {
 				logger.Printf("Timeout, command '%s', test '%s'. Error: %s, Stderr: %s\n", v.Command, v.Name, err.Error(), strconv.Quote(stderr))
@@ -310,7 +310,7 @@ func main() {
 			if v.NoLog == false {
 				var t = Result{Name: v.Name, Command: v.Command, Stdout: strings.Split(stdout, "\n"), Stderr: strings.Split(stderr, "\n")}
 
-				if (err == nil || v.IgnoreExitCode) && textErr == nil {
+				if ((err == nil || v.IgnoreExitCode) && textErr == nil) || textErr == nil /* fixes throwing error on expected stderr */ {
 					t.Status = "ok"
 					if err != nil { // Here we have ignore_exit_code
 						t.Exit = "(ignore) " + strings.Replace(err.Error(), "exit status ", "", 1)


### PR DESCRIPTION
- fix acting expected stderr as an error in logs and results, no need for ignore_exit_code to be present for expected stderr.

-  Add the ability to pass if at least one expected output found by introducing the 'partial: true'

Example:


```yml
    - name: I can see all connectors
      command: >-
        lenses-cli connectors --clusterName=* --names --no-json
      stdout:
        - match: [ "logs-broker", "nullsink", "or that"] # at least one found.
          partial: true
```

And the best, the below will fail because `partial:true` is per match(es):

```yml
    - name: I can see all connectors
      command: >-
        lenses-cli connectors --clusterName=* --names --no-json
      stdout:
           # at least one found but test failed because of the second match.
        - match: [ "logs-broker", "nullsink", "or that"]
          partial: true
        - match: ["this should be there but it's not"]
```

Use case: we want to pass the test if error can be `failed with status code: 403` or `user has no access to do that action`, we can do:

 ```yml
stderr:
  - match: [ "failed with", "no access"]
    partial: true
```

or `failed with status code 500` and `failed because other reason` [ this is just one - match value which should be contained to the output in order to pass, like the above ]

```yml
stderr:
  - match: ["failed"]
    partial: true
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/coyote/9)
<!-- Reviewable:end -->
