### PR TITLE
Add `Entry#TestCommand`, `TextEntryGroupLoader` and `TestBackwardsCompatibility` test case

### DIFF
--- a/entry_group.go
+++ b/entry_group.go
@@ -54,9 +54,9 @@ type EntryLoader interface {
 	Load(groups *[]EntryGroup) error
 }
 
-// FileEntryLoader is an implementation of the `EntryLoader`
+// FileEntryGroupLoader is an implementation of the `EntryLoader`
 // which loads a set of `EntryGroup` based on caller-specific yaml files.
-type FileEntryLoader []string
+type FileEntryGroupLoader []string
 
 // AddFile adds file(s) to be loaded on `Load`.
 // Note that it doesn't check for file existence, only `Load` does that.
@@ -80,7 +80,7 @@ type FileEntryLoader []string
 // }
 
 // Load updates the "groups" based on the contents of the corresponding yaml files.
-func (l FileEntryLoader) Load(groups *[]EntryGroup) error {
+func (l FileEntryGroupLoader) Load(groups *[]EntryGroup) error {
 	for idx, file := range l {
 		data, err := ioutil.ReadFile(file)
 		if err != nil {
@@ -105,5 +105,20 @@ func (l FileEntryLoader) Load(groups *[]EntryGroup) error {
 		mergeEntryGroups(groups, newGroups)
 	}
 
+	return nil
+}
+
+// TextEntryGroupLoader is an implementation of the `EntryLoader`
+// which loads a set of `EntryGroup` based on caller-specific yaml raw text contents.
+type TextEntryGroupLoader []byte
+
+// Load updates the "groups" based on the contents of the corresponding raw yaml contents.
+func (l TextEntryGroupLoader) Load(groups *[]EntryGroup) error {
+	var newGroups []EntryGroup
+	if err := yaml.Unmarshal(l, &newGroups); err != nil {
+		return fmt.Errorf("error reading configuration contents: %v", err)
+	}
+
+	mergeEntryGroups(groups, newGroups)
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func main() {
 	// Set the available loaders to load EntryGroups from.
 	var loaders = []EntryLoader{
 		// from yaml file(s) configuration.
-		FileEntryLoader(configFilesArray),
+		FileEntryGroupLoader(configFilesArray),
 	}
 
 	// Load the set of `EntryGroup` based on the available `EntryLoader`s.


### PR DESCRIPTION
Add `Entry#TestCommand` and `TextEntryGroupLoader` to be able to test basic raw content via code: Add `TestBackwardsCompatibility` to test and fix the `stdout_has, stdout_not_has, stderr_has, stderr_not_has` functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/coyote/11)
<!-- Reviewable:end -->
