### PR TITLE
add '-run' command flag to run a set of groups by their names (regex)  

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -15,13 +15,14 @@ import (
 type (
 	// Entry contains the test case's entries' structure, see examples for more.
 	Entry struct {
-		Name    string        `yaml:"name"`
-		WorkDir string        `yaml:"workdir"`
-		Command string        `yaml:"command,omitempty"`
-		Stdin   string        `yaml:"stdin,omitempty"`
-		NoLog   bool          `yaml:"nolog,omitempty"`
-		EnvVars []string      `yaml:"env,omitempty"`
-		Timeout time.Duration `yaml:"timeout,omitempty"`
+		Name        string        `yaml:"name"`
+		Description string        `yaml:"description,omitempty"`
+		WorkDir     string        `yaml:"workdir"`
+		Command     string        `yaml:"command,omitempty"`
+		Stdin       string        `yaml:"stdin,omitempty"`
+		NoLog       bool          `yaml:"nolog,omitempty"`
+		EnvVars     []string      `yaml:"env,omitempty"`
+		Timeout     time.Duration `yaml:"timeout,omitempty"`
 
 		// It differs from the `Timeout`,
 		// `SleepBefore` will wait for 'x' duration before the execution of this command.

--- a/entry_group.go
+++ b/entry_group.go
@@ -9,13 +9,14 @@ import (
 )
 
 type EntryGroup struct {
-	Name    string            `yaml:"name"`
-	Entries []Entry           `yaml:"entries"`
-	Title   string            `yaml:"title,omitempty"`
-	Skip    string            `yaml:"skip"`
-	NoSkip  string            `yaml:"noskip,omitempty"`
-	Type    string            `yaml:"type,omitempty"`
-	Vars    map[string]string `yaml:"vars,omitempty"`
+	Name        string            `yaml:"name"`
+	Description string            `yaml:"description,omitempty"`
+	Entries     []Entry           `yaml:"entries"`
+	Title       string            `yaml:"title,omitempty"`
+	Skip        string            `yaml:"skip"`
+	NoSkip      string            `yaml:"noskip,omitempty"`
+	Type        string            `yaml:"type,omitempty"`
+	Vars        map[string]string `yaml:"vars,omitempty"`
 }
 
 // mergeEntryGroups appends the entries of the "newGroups" to the "groups".


### PR DESCRIPTION
Add a '-run' command flag to run a set of groups by their names (regex).

Run tests against a particular set of entries by group name (regex). Works in converse of the inline `skip` YAML option.

**Usage**

`coyote -c="./mytests" -run="Test Admin Write"`


And add `Description` ("description") field for test groups and test entries (not shown in the template yet)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/coyote/13)
<!-- Reviewable:end -->
